### PR TITLE
Center app wrapper within viewport

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -23,6 +23,7 @@ body {
 .app__wrapper {
   width: 100%;
   max-width: 64rem;
+  margin: 0 auto;
 }
 
 .app__header {


### PR DESCRIPTION
## Summary
- add automatic horizontal margin to `.app__wrapper` so layout centers on large viewports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce2c1fbbc88329a71c1579f54b387a