### PR TITLE
Centralize global CSS defaults

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,13 +1,3 @@
-:root {
-  color-scheme: dark;
-  font-family: "Noto Sans JP", "Helvetica Neue", Arial, sans-serif;
-}
-
-body {
-  margin: 0;
-  background: #05060b;
-}
-
 .app {
   min-height: 100vh;
   display: flex;

--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,9 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: "Noto Sans JP", "Helvetica Neue", Arial, system-ui, Avenir, Helvetica, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
+  color-scheme: dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;
 
@@ -27,6 +27,7 @@ body {
   display: block;
   min-width: 320px;
   min-height: 100vh;
+  background-color: #05060b;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- consolidate the global `:root` and `body` styles in `src/index.css` so fonts, color scheme, and layout defaults live in one place
- remove the duplicate selectors from `src/App.css`, keeping only component-scoped rules
- keep the application background color defined globally on the `body`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce394c4f4c83298e7641448a92b015