### PR TITLE
Fix overlapping inputs and scope background

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,13 +1,3 @@
-:root {
-  color-scheme: dark;
-  font-family: "Noto Sans JP", "Helvetica Neue", Arial, sans-serif;
-}
-
-body {
-  margin: 0;
-  background: #05060b;
-}
-
 .app {
   min-height: 100vh;
   display: flex;
@@ -16,7 +6,7 @@ body {
   padding: 3rem 1.5rem;
   background: radial-gradient(circle at top, rgba(37, 99, 235, 0.2), transparent 55%),
     radial-gradient(circle at bottom, rgba(16, 185, 129, 0.15), transparent 55%),
-    #0b0d14;
+    #05060b;
   color: #f8fafc;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,15 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: "Noto Sans JP", "Helvetica Neue", Arial, system-ui, Avenir, Helvetica, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
+  color-scheme: dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;
 


### PR DESCRIPTION
## Summary
- add a global border-box sizing reset so the settings inputs stay within their grid tracks
- scope the dark backdrop to the `.app` container so the component owns its background fallback color

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ce394c4f4c83298e7641448a92b015