### PR TITLE
Allow typing raw range bounds before quiz normalization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -221,7 +221,11 @@ export default function YojijukugoDrill() {
                   min={1}
                   max={maxN}
                   value={rangeStart}
-                  onChange={(e) => setRangeStart(clamp(Number(e.target.value), 1, maxN))}
+                  onChange={(e) => {
+                    const nextValue = Number(e.target.value);
+                    if (Number.isNaN(nextValue)) return;
+                    setRangeStart(nextValue);
+                  }}
                   className="field__input"
                 />
               </div>
@@ -232,7 +236,11 @@ export default function YojijukugoDrill() {
                   min={1}
                   max={maxN}
                   value={rangeEnd}
-                  onChange={(e) => setRangeEnd(clamp(Number(e.target.value), 1, maxN))}
+                  onChange={(e) => {
+                    const nextValue = Number(e.target.value);
+                    if (Number.isNaN(nextValue)) return;
+                    setRangeEnd(nextValue);
+                  }}
                   className="field__input"
                 />
               </div>


### PR DESCRIPTION
## Summary
- stop clamping the quiz range lower and upper inputs while typing so users can enter multi-digit values naturally
- retain the startQuiz normalization so bounds are clamped and ordered when the quiz begins

## Testing
- npm run build
- Manual verification: set範囲下限 to 12 and 範囲上限 to 25, started quiz and confirmed question loads

------
https://chatgpt.com/codex/tasks/task_e_68dce8e041bc8329a3490e308fd6a7a5